### PR TITLE
Don't pass --fast-parser flag anymore

### DIFF
--- a/autoload/mypy.vim
+++ b/autoload/mypy.vim
@@ -11,5 +11,5 @@
 
 function mypy#ExecuteMyPy()
   silent !clear
-  execute "!mypy --ignore-missing-imports --follow-imports=skip --fast-parser " . bufname("%")
+  execute "!mypy --ignore-missing-imports --follow-imports=skip " . bufname("%")
 endfunction


### PR DESCRIPTION
Since January 2017, it is now enabled by default and the only parser available.
https://github.com/python/mypy/pull/2734